### PR TITLE
Attempt to add Bps speed option

### DIFF
--- a/Resource_Monitor@Ory0n/prefs.js
+++ b/Resource_Monitor@Ory0n/prefs.js
@@ -381,6 +381,7 @@ const ResourceMonitorPrefsWidget = GObject.registerClass(
             });
 
             let auto = new SwitchRow('Enable', this._settings, 'autohide');
+            let bps = new SwitchRow('Enable', this._settings, 'bpsspeed');
             let wlan = new SwitchRow('Display', this._settings, 'wlan');
             let eth = new SwitchRow('Display', this._settings, 'eth');
             let widthWlan = new SpinButtonRow('Width', this._settings, 'widthwlan');
@@ -392,6 +393,12 @@ const ResourceMonitorPrefsWidget = GObject.registerClass(
                 halign: Gtk.Align.START
             }));
             box.append(auto);
+            box.append(new Gtk.Label({
+                label: '<b>%s</b>'.format(_('Bits per second')),
+                use_markup: true,
+                halign: Gtk.Align.START
+            }));
+            box.append(bps);
             box.append(new Gtk.Label({
                 label: '<b>%s</b>'.format(_('Eth')),
                 use_markup: true,

--- a/Resource_Monitor@Ory0n/schemas/com.github.Ory0n.Resource_Monitor.gschema.xml
+++ b/Resource_Monitor@Ory0n/schemas/com.github.Ory0n.Resource_Monitor.gschema.xml
@@ -111,6 +111,11 @@
             <summary>Auto Hide Net</summary>
             <description></description>
         </key>
+        <key name="bpsspeed" type="b">
+            <default>false</default>
+            <summary>Speed in Bits per Second</summary>
+            <description></description>
+        </key>
         <key name="cputemperatureunit" type="b">
             <default>false</default>
             <summary>Cpu Temperature Unit Fahrenheit</summary>


### PR DESCRIPTION
Hello. I tried to make an attempt to add Bps speed option since the monitor shows network speed in Byte/s unit only. Fixes #27 

I made this with my Javascript knowledge. Didn't test it because I don't know how to do it in Gnome environment. Anyway if it's not working I think it could be a good start to you to fix little things in very short time, most of the work could have be done.

`bpsspeed` option has been added as a Boolean. It's false as default, so the eth/wlan refresh methods pick byte values and show them as previously done.

If it is set to true, the speed values are multiplied by 8 (`factor` variable, default to 1), so they are converted to bit.

Then, discovering multiple unit (kilo, mega, giga), a `unit` variable is used to divide: 1024 as default, 1000 for bpsspeed as true.

According to bpsspeed value, an uppercase/lowercase unit letter is showed.

Hope this works.

Let me know if something has been done wrong. Thanks. 

## Checklist

- [ ] Your code builds clean without any errors or warnings.
- [ ] You are using approved terminology.
