### PR TITLE
Added gnome-usage as fallback

### DIFF
--- a/Resource_Monitor@Ory0n/extension.js
+++ b/Resource_Monitor@Ory0n/extension.js
@@ -462,12 +462,12 @@ const ResourceMonitor = GObject.registerClass(
 
                 default:
                     if (this._systemMonitorStatus) {
-                        let app = global.log(Shell.AppSystem.get_default().lookup_app('gnome-system-monitor.desktop'));
-
-                        if (app != null)
-                            app.activate();
-                        else
+                        if(Shell.AppSystem.get_default().lookup_app('gnome-system-monitor.desktop')){
                             Util.spawn(['gnome-system-monitor']);
+                        }
+                        else{
+                            Util.spawn(['gnome-usage']);
+                        }    
                     }
 
                     break;
@@ -1720,3 +1720,4 @@ class Extension {
 function init(meta) {
     return new Extension(meta.uuid);
 }
+


### PR DESCRIPTION
Thank you for your contribution to the Resource_Monitor repo.

## Motivation
Clicking the extensions tries to launch gnome-system-monitor

## Description
My EndeavourOS  (and possibly others) doesn't have gnome-system-monitor which has been replaced by gnome-usage anyways. This PR checks if gnome-system-monitor can be launched, and if not it opens gnome-usage.

## Checklist

- [ X] Your code builds clean without any errors or warnings.
- [X ] You are using approved terminology.
