### PR TITLE
Port to Gnome 45: initial efforts

### DIFF
--- a/Resource_Monitor@Ory0n/extension.js
+++ b/Resource_Monitor@Ory0n/extension.js
@@ -31,7 +31,12 @@ import * as Util from 'resource:///org/gnome/shell/misc/util.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 
-import NM from 'gi://NM';
+let NM;
+try {
+    NM = (await import('gi://NM')).default;
+} catch (error) {
+    log('[Resource_Monitor] NetworkManager not found (' + error + '): The \"Auto Hide\" feature has been disabled');
+}
 
 let extension;
 

--- a/Resource_Monitor@Ory0n/extension.js
+++ b/Resource_Monitor@Ory0n/extension.js
@@ -1,6 +1,5 @@
 /* -*- mode: js2; js2-basic-offset: 4; indent-tabs-mode: nil -*- */
 /* exported init */
-
 /*
  * Resource_Monitor is Copyright © 2018-2023 Giuseppe Silvestro
  *
@@ -20,33 +19,21 @@
  * along with Resource_Monitor. If not, see <http://www.gnu.org/licenses/>.
  */
 
-'use strict';
+import GObject from 'gi://GObject';
+import St from 'gi://St';
+import Gio from 'gi://Gio';
+import Clutter from 'gi://Clutter';
+import GLib from 'gi://GLib';
+import Shell from 'gi://Shell';
 
-const GETTEXT_DOMAIN = 'com-github-Ory0n-Resource_Monitor';
+import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Util from 'resource:///org/gnome/shell/misc/util.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 
-const { GObject, St, Gio, Clutter, GLib, Shell } = imports.gi;
+import NM from 'gi://NM';
 
-var NM;
-try {
-    NM = imports.gi.NM;
-} catch (error) {
-    log('[Resource_Monitor] NetworkManager not found (' + error + '): The \"Auto Hide\" feature has been disabled');
-}
-
-const ExtensionUtils = imports.misc.extensionUtils;
-const Util = imports.misc.util;
-const Main = imports.ui.main;
-const PanelMenu = imports.ui.panelMenu;
-const ByteArray = imports.byteArray;
-const Gettext = imports.gettext;
-
-const Me = ExtensionUtils.getCurrentExtension();
-const IndicatorName = Me.metadata.name;
-
-const Domain = Gettext.domain(Me.metadata.uuid);
-
-const _ = Domain.gettext;
-const ngettext = Domain.ngettext;
+let extension;
 
 // Settings
 const REFRESH_TIME = 'refreshtime';
@@ -121,7 +108,7 @@ const GPU_DEVICES_LIST_SEPARATOR = ':';
 const ResourceMonitor = GObject.registerClass(
     class ResourceMonitor extends PanelMenu.Button {
         _init(settings) {
-            super._init(0.0, _(IndicatorName));
+            super._init(0.0, _(extension.metadata.name));
 
             this._settings = settings;
 
@@ -187,42 +174,42 @@ const ResourceMonitor = GObject.registerClass(
 
             // Icon
             this._cpuIcon = new St.Icon({
-                gicon: Gio.icon_new_for_string(Me.path + '/icons/cpu-symbolic.svg'),
+                gicon: Gio.icon_new_for_string(extension.path + '/icons/cpu-symbolic.svg'),
                 style_class: 'system-status-icon'
             });
 
             this._ramIcon = new St.Icon({
-                gicon: Gio.icon_new_for_string(Me.path + '/icons/ram-symbolic.svg'),
+                gicon: Gio.icon_new_for_string(extension.path + '/icons/ram-symbolic.svg'),
                 style_class: 'system-status-icon'
             });
 
             this._swapIcon = new St.Icon({
-                gicon: Gio.icon_new_for_string(Me.path + '/icons/swap-symbolic.svg'),
+                gicon: Gio.icon_new_for_string(extension.path + '/icons/swap-symbolic.svg'),
                 style_class: 'system-status-icon'
             });
 
             this._diskStatsIcon = new St.Icon({
-                gicon: Gio.icon_new_for_string(Me.path + '/icons/disk-stats-symbolic.svg'),
+                gicon: Gio.icon_new_for_string(extension.path + '/icons/disk-stats-symbolic.svg'),
                 style_class: 'system-status-icon'
             });
 
             this._diskSpaceIcon = new St.Icon({
-                gicon: Gio.icon_new_for_string(Me.path + '/icons/disk-space-symbolic.svg'),
+                gicon: Gio.icon_new_for_string(extension.path + '/icons/disk-space-symbolic.svg'),
                 style_class: 'system-status-icon'
             });
 
             this._ethIcon = new St.Icon({
-                gicon: Gio.icon_new_for_string(Me.path + '/icons/eth-symbolic.svg'),
+                gicon: Gio.icon_new_for_string(extension.path + '/icons/eth-symbolic.svg'),
                 style_class: 'system-status-icon'
             });
 
             this._wlanIcon = new St.Icon({
-                gicon: Gio.icon_new_for_string(Me.path + '/icons/wlan-symbolic.svg'),
+                gicon: Gio.icon_new_for_string(extension.path + '/icons/wlan-symbolic.svg'),
                 style_class: 'system-status-icon'
             });
 
             this._gpuIcon = new St.Icon({
-                gicon: Gio.icon_new_for_string(Me.path + '/icons/gpu-symbolic.svg'),
+                gicon: Gio.icon_new_for_string(extension.path + '/icons/gpu-symbolic.svg'),
                 style_class: 'system-status-icon'
             });
 
@@ -626,7 +613,7 @@ const ResourceMonitor = GObject.registerClass(
             switch (event.get_button()) {
                 case 3: // Right Click
                     if (this._rightClickStatus) {
-                        ExtensionUtils.openPrefs();
+                        extension.openPreferences();
                     }
 
                     break;
@@ -635,7 +622,7 @@ const ResourceMonitor = GObject.registerClass(
 
                 default:
                     if (this._leftClickStatus !== "") {
-                        let app = global.log(Shell.AppSystem.get_default().lookup_app(this._leftClickStatus + '.desktop'));
+                        let app = log(Shell.AppSystem.get_default().lookup_app(this._leftClickStatus + '.desktop'));
 
                         if (app != null) {
                             app.activate();
@@ -1325,7 +1312,7 @@ const ResourceMonitor = GObject.registerClass(
 
         _refreshCpuValue() {
             this._loadFile('/proc/stat').then(contents => {
-                const lines = ByteArray.toString(contents).split('\n');
+                const lines = new TextDecoder().decode(contents).split('\n');
 
                 const entry = lines[0].trim().split(/\s+/);
                 let cpuTot = 0;
@@ -1353,7 +1340,7 @@ const ResourceMonitor = GObject.registerClass(
 
         _refreshRamValue() {
             this._loadFile('/proc/meminfo').then(contents => {
-                const lines = ByteArray.toString(contents).split('\n');
+                const lines = new TextDecoder().decode(contents).split('\n');
 
                 let total, available, used;
 
@@ -1462,7 +1449,7 @@ const ResourceMonitor = GObject.registerClass(
 
         _refreshSwapValue() {
             this._loadFile('/proc/meminfo').then(contents => {
-                const lines = ByteArray.toString(contents).split('\n');
+                const lines = new TextDecoder().decode(contents).split('\n');
 
                 let total, available, used;
 
@@ -1571,7 +1558,7 @@ const ResourceMonitor = GObject.registerClass(
 
         _refreshDiskStatsValue() {
             this._loadFile('/proc/diskstats').then(contents => {
-                const lines = ByteArray.toString(contents).split('\n');
+                const lines = new TextDecoder().decode(contents).split('\n');
 
                 switch (this._diskStatsMode) {
                     case 'single':
@@ -1892,7 +1879,7 @@ const ResourceMonitor = GObject.registerClass(
 
         _refreshEthValue() {
             this._loadFile('/proc/net/dev').then(contents => {
-                const lines = ByteArray.toString(contents).split('\n');
+                const lines = new TextDecoder().decode(contents).split('\n');
 
                 let duTot = [0, 0];
                 let du = [0, 0];
@@ -2007,7 +1994,7 @@ const ResourceMonitor = GObject.registerClass(
 
         _refreshWlanValue() {
             this._loadFile('/proc/net/dev').then(contents => {
-                const lines = ByteArray.toString(contents).split('\n');
+                const lines = new TextDecoder().decode(contents).split('\n');
 
                 let duTot = [0, 0];
                 let du = [0, 0];
@@ -2123,7 +2110,7 @@ const ResourceMonitor = GObject.registerClass(
         _refreshCpuFrequencyValue() {
             if (GLib.file_test('/sys/devices/system/cpu/cpu1/cpufreq/scaling_cur_freq', GLib.FileTest.EXISTS)) {
                 this._loadFile('/sys/devices/system/cpu/cpu1/cpufreq/scaling_cur_freq').then(contents => {
-                    let value = parseInt(ByteArray.toString(contents));
+                    let value = parseInt(new TextDecoder().decode(contents));
                     let unit = "";
 
                     switch (this._cpuFrequencyUnitMeasure) {
@@ -2175,7 +2162,7 @@ const ResourceMonitor = GObject.registerClass(
 
         _refreshCpuLoadAverageValue() {
             this._loadFile('/proc/loadavg').then(contents => {
-                const lines = ByteArray.toString(contents).split('\n');
+                const lines = new TextDecoder().decode(contents).split('\n');
 
                 const entry = lines[0].trim().split(/\s/);
 
@@ -2202,7 +2189,7 @@ const ResourceMonitor = GObject.registerClass(
 
                     if (GLib.file_test(path, GLib.FileTest.EXISTS)) {
                         this._loadFile(path).then(contents => {
-                            const value = parseInt(ByteArray.toString(contents));
+                            const value = parseInt(new TextDecoder().decode(contents));
 
                             this._cpuTemperatures += value / 1000;
                             this._cpuTemperaturesReads++;
@@ -2866,15 +2853,11 @@ const GpuContainer = GObject.registerClass(
         }
     });
 
-class Extension {
-    constructor(uuid) {
-        this._uuid = uuid;
-
-        ExtensionUtils.initTranslations(GETTEXT_DOMAIN);
-    }
-
+export default class ResourceMonitorExtension extends Extension {
     enable() {
-        this._settings = ExtensionUtils.getSettings();
+        extension = this;
+
+        this._settings = this.getSettings();
         this._indicator = new ResourceMonitor(this._settings);
 
         const index = {
@@ -2891,21 +2874,19 @@ class Extension {
             this._indicator = null;
             this._indicator = new ResourceMonitor(this._settings);
 
-            Main.panel.addToStatusArea(this._uuid, this._indicator, index[this._extensionPosition], this._extensionPosition);
+            Main.panel.addToStatusArea(this.uuid, this._indicator, index[this._extensionPosition], this._extensionPosition);
         });
 
-        Main.panel.addToStatusArea(this._uuid, this._indicator, index[this._extensionPosition], this._extensionPosition);
+        Main.panel.addToStatusArea(this.uuid, this._indicator, index[this._extensionPosition], this._extensionPosition);
     }
 
     disable() {
+        extension = null;
+
         // Disconnect Signal
         this._settings.disconnect(this._handlerId);
 
         this._indicator.destroy();
         this._indicator = null;
     }
-}
-
-function init(meta) {
-    return new Extension(meta.uuid);
 }

--- a/Resource_Monitor@Ory0n/metadata.json
+++ b/Resource_Monitor@Ory0n/metadata.json
@@ -5,14 +5,7 @@
   "gettext-domain": "com-github-Ory0n-Resource_Monitor",
   "name": "Resource Monitor",
   "settings-schema": "com.github.Ory0n.Resource_Monitor",
-  "shell-version": [
-    "40",
-    "41",
-    "42",
-    "43",
-    "44",
-    "45"
-  ],
+  "shell-version": ["45"],
   "url": "https://github.com/0ry0n/Resource_Monitor/",
   "uuid": "Resource_Monitor@Ory0n",
   "version": 19

--- a/Resource_Monitor@Ory0n/metadata.json
+++ b/Resource_Monitor@Ory0n/metadata.json
@@ -10,7 +10,8 @@
     "41",
     "42",
     "43",
-    "44"
+    "44",
+    "45"
   ],
   "url": "https://github.com/0ry0n/Resource_Monitor/",
   "uuid": "Resource_Monitor@Ory0n",

--- a/Resource_Monitor@Ory0n/prefs.js
+++ b/Resource_Monitor@Ory0n/prefs.js
@@ -27,10 +27,6 @@ import Gdk from 'gi://Gdk';
 
 import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-let gettext_domain;
-let settings;
-let dir;
-
 // Settings
 const REFRESH_TIME = 'refreshtime';
 const EXTENSION_POSITION = 'extensionposition';
@@ -132,10 +128,14 @@ const ResourceMonitorPrefsWidget = GObject.registerClass(
             settings.bind(settingsName, element, 'active', Gio.SettingsBindFlags.DEFAULT);
         }
 
-        _init() {
+        _init({settings, domain, dir}) {
+            this._settings = settings;
+            this._gettextDomain = domain;
+            this._dir = dir;
+
             // Gtk Css Provider
             this._provider = new Gtk.CssProvider();
-            this._provider.load_from_path(dir.get_path() + '/prefs.css');
+            this._provider.load_from_path(this._dir.get_path() + '/prefs.css');
             Gtk.StyleContext.add_provider_for_display(
                 Gdk.Display.get_default(),
                 this._provider,
@@ -144,12 +144,8 @@ const ResourceMonitorPrefsWidget = GObject.registerClass(
             // Gtk Builder
             this._builder = new Gtk.Builder();
             this._builder.set_scope(new ResourceMonitorBuilderScope());
-            this._builder.set_translation_domain(gettext_domain);
-            this._builder.add_from_file(dir.get_path() + '/prefs.ui');
-
-            // Settings
-            this._settings = settings;
-            settings = null;
+            this._builder.set_translation_domain(this._gettextDomain);
+            this._builder.add_from_file(this._dir.get_path() + '/prefs.ui');
 
             // PREFS
             this.notebook = this._builder.get_object('main_notebook');
@@ -1008,17 +1004,12 @@ const ResourceMonitorPrefsWidget = GObject.registerClass(
     });
 
 export default class ExamplePreferences extends ExtensionPreferences {
-    constructor(metadata) {
-        super(metadata);
-
-        gettext_domain = metadata["gettext-domain"]
-    }
-
     getPreferencesWidget() {
-        dir = this.dir;
-        settings = this.getSettings();
-
-        const widget = new ResourceMonitorPrefsWidget();
+        const widget = new ResourceMonitorPrefsWidget({
+            dir: this.dir,
+            settings: this.getSettings(),
+            domain: this.metadata["gettext-domain"]
+        });
 
         return widget.notebook;
     }

--- a/Resource_Monitor@Ory0n/prefs.js
+++ b/Resource_Monitor@Ory0n/prefs.js
@@ -20,21 +20,16 @@
  * along with Resource_Monitor. If not, see <http://www.gnu.org/licenses/>.
  */
 
-'use strict';
+import Gio from 'gi://Gio';
+import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk';
+import Gdk from 'gi://Gdk';
 
-const GETTEXT_DOMAIN = 'com-github-Ory0n-Resource_Monitor';
+import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-const { Gio, GObject, Gtk, Gdk, GLib } = imports.gi;
-
-const ExtensionUtils = imports.misc.extensionUtils;
-const ByteArray = imports.byteArray;
-const Me = ExtensionUtils.getCurrentExtension();
-const Gettext = imports.gettext;
-
-const Domain = Gettext.domain(Me.metadata.uuid);
-
-const _ = Domain.gettext;
-const ngettext = Domain.ngettext;
+let gettext_domain;
+let settings;
+let dir;
 
 // Settings
 const REFRESH_TIME = 'refreshtime';
@@ -140,7 +135,7 @@ const ResourceMonitorPrefsWidget = GObject.registerClass(
         _init() {
             // Gtk Css Provider
             this._provider = new Gtk.CssProvider();
-            this._provider.load_from_path(Me.dir.get_path() + '/prefs.css');
+            this._provider.load_from_path(dir.get_path() + '/prefs.css');
             Gtk.StyleContext.add_provider_for_display(
                 Gdk.Display.get_default(),
                 this._provider,
@@ -149,11 +144,12 @@ const ResourceMonitorPrefsWidget = GObject.registerClass(
             // Gtk Builder
             this._builder = new Gtk.Builder();
             this._builder.set_scope(new ResourceMonitorBuilderScope());
-            this._builder.set_translation_domain(GETTEXT_DOMAIN);
-            this._builder.add_from_file(Me.dir.get_path() + '/prefs.ui');
+            this._builder.set_translation_domain(gettext_domain);
+            this._builder.add_from_file(dir.get_path() + '/prefs.ui');
 
             // Settings
-            this._settings = ExtensionUtils.getSettings();
+            this._settings = settings;
+            settings = null;
 
             // PREFS
             this.notebook = this._builder.get_object('main_notebook');
@@ -509,7 +505,7 @@ const ResourceMonitorPrefsWidget = GObject.registerClass(
 
                 if (all) {
                     this._loadFile('/proc/diskstats').then(contents => {
-                        const lines = ByteArray.toString(contents).split('\n');
+                        const lines = new TextDecoder().decode(contents).split('\n');
 
                         for (let i = 0; i < lines.length - 1; i++) {
                             const line = lines[i];
@@ -1011,13 +1007,21 @@ const ResourceMonitorPrefsWidget = GObject.registerClass(
         }
     });
 
-function init() {
-    ExtensionUtils.initTranslations(GETTEXT_DOMAIN);
+export default class ExamplePreferences extends ExtensionPreferences {
+    constructor(metadata) {
+        super(metadata);
+
+        gettext_domain = metadata["gettext-domain"]
+    }
+
+    getPreferencesWidget() {
+        dir = this.dir;
+        settings = this.getSettings();
+
+        const widget = new ResourceMonitorPrefsWidget();
+
+        return widget.notebook;
+    }
 }
 
-function buildPrefsWidget() {
-    const widget = new ResourceMonitorPrefsWidget();
-
-    return widget.notebook;
-}
 


### PR DESCRIPTION
This makes it work on Gnome 45, but it's not perfect as of now.

~~I am fairly sure this breaks backwards compatibility entirely, which is a very major issue that has to be solved.~~

After consulting with people in [#extensions:gnome.org](https://matrix.to/#/#extensions:gnome.org), it appears that the solution to backwards compatibility, is not doing backwards compatibility.  
Users will fetch the latest version of the extension their shell supports, so, codebases for 45+ and <44 should live in two different branches and be maintained, packaged, and uploaded separately.


~~Imports cannot be wrapped around try-catch, rendering `gi://NM` a hard dependency, at this point.  
I'm not sure what's the best way to re-implement the old behavior (or if there is one, for that matter), so that's something that needs to be looked into.~~

Fixed. Courtesy of @Braayy.


~~Certain values are made accessible to class instances via global variables (those being `extension` in extenion.js; and `gettext_domain`, `settings`, and `dir` in prefs.js). This works, as a proof of concept, but needs to be implemented properly.  
I am very much unfamiliar with this codebase, so I tried to keep things as intact as possible, hence this workaround.~~

Replaced globals with dependency injection.  
I think in this case the proper solution would be to re-factor the code, but I don't really feel comfortable doing that.


Other changes:
Legacy ByteArray has been replaced with TextDecoder.
`global.log` has been replaces with `log`, because `global.log` does not exist.