### PR TITLE
Add zenpower thermal sensors for Ryzen CPU's

### DIFF
--- a/Resource_Monitor@Ory0n/prefs.js
+++ b/Resource_Monitor@Ory0n/prefs.js
@@ -1025,7 +1025,7 @@ const ResourceMonitorPrefsWidget = GObject.registerClass(
           this._executeCommand([
             "bash",
             "-c",
-            'for i in /sys/class/hwmon/hwmon*/temp*_input; do NAME="$(<$(dirname $i)/name)"; if [[ "$NAME" == "coretemp" ]] || [[ "$NAME" == "k10temp" ]]; then echo "$NAME: $(cat ${i%_*}_label 2>/dev/null || echo $(basename ${i%_*}))-$i"; fi done',
+            'for i in /sys/class/hwmon/hwmon*/temp*_input; do NAME="$(<$(dirname $i)/name)"; if [[ "$NAME" == "coretemp" ]] || [[ "$NAME" == "k10temp" ]] || [[ "$NAME" == "zenpower" ]]; then echo "$NAME: $(cat ${i%_*}_label 2>/dev/null || echo $(basename ${i%_*}))-$i"; fi done',
           ]).then((output) => {
             let lines = output.split("\n");
 


### PR DESCRIPTION
## Motivation
Zenpower kernel driver replaces k10temp
## Description
Added zenpower thermal sensors for Ryzen CPU's
## Checklist

- [x] Your code builds clean without any errors or warnings.
- [X] You are using approved terminology.