### PR TITLE
enable support for Gnome 47 @ metadata.json

### DIFF
--- a/Resource_Monitor@Ory0n/metadata.json
+++ b/Resource_Monitor@Ory0n/metadata.json
@@ -4,7 +4,8 @@
   "description": "Monitor the use of system resources like cpu, ram, disk, network and display them in gnome shell top bar.",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ],
   "url": "https://github.com/0ry0n/Resource_Monitor/",
   "donations": {


### PR DESCRIPTION
## Motivation

Gnome 47 has been released recently, but is not yet supported by this extension.
Apparently no changes to gnome actually affect the functionality of the Resource_Monitor extension.

## Description

- This path just adds Gnome 47 to the supported versions in metadata.json

## Checklist

- I tested functionality of these changes against the main branch not the development branch