### PR TITLE
Add Gnome 47 to the list of supported versions.

### DIFF
--- a/Resource_Monitor@Ory0n/metadata.json
+++ b/Resource_Monitor@Ory0n/metadata.json
@@ -4,7 +4,8 @@
   "description": "Monitor the use of system resources like cpu, ram, disk, network and display them in gnome shell top bar.",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ],
   "url": "https://github.com/0ry0n/Resource_Monitor/",
   "donations": {


### PR DESCRIPTION
Thank you for your contribution to the Resource_Monitor repo.

## Motivation

I just upgraded to 24.10 which is running Gnome 47.

## Description

The [upgrade guide](https://gjs.guide/extensions/upgrading/gnome-shell-47.html) didn't indicate anything (to me) that was obviously relevant. The extension is working for me locally without any other changes.

## Checklist

- [x] Your code builds clean without any errors or warnings.
- [x] You are using approved terminology.
