### PR TITLE
added GNOME 48 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Resource_Monitor is a GNOME Shell extension that provides real-time monitoring o
 | ![Main View](/images/main.png) |
 
 ## GNOME Shell versions supported
-**45, 46, 47**
+**45, 46, 47, 48**
 - For older GNOME versions see the [gnome-3.28-3.38](../../tree/gnome-3.28-3.38) or [gnome-40-44](../../tree/gnome-40-44) branch.
 
 ## How-To Install

--- a/Resource_Monitor@Ory0n/metadata.json
+++ b/Resource_Monitor@Ory0n/metadata.json
@@ -2,7 +2,7 @@
   "name": "Resource Monitor",
   "uuid": "Resource_Monitor@Ory0n",
   "description": "Resource Monitor is a GNOME Shell extension that provides real-time monitoring of key system resources directly in the GNOME Shell top bar. It tracks CPU usage, load average, and temperature; RAM and swap usage; disk stats and space; GPU usage, memory, and temperature; and network activity for both WLAN and Ethernet connections.",
-  "shell-version": ["45", "46", "47"],
+  "shell-version": ["45", "46", "47", "48"],
   "url": "https://github.com/0ry0n/Resource_Monitor/",
   "donations": {
     "paypal": "0ry0n"


### PR DESCRIPTION
## Motivation

GNOME 48 has been released recently, so the extension won't work without a version bump.

## Description

Just a regular version bump with no additional code changes. The extension runs fine on my Arch Linux with GNOME 48 with these changes.

Edit / Note: I only did some basic testing. I only use the RAM and CPU display and I've clicked through the extension settings a bit to confirm nothing is completely broken. So it might be a good idea to test the remaining functionality a bit more thoroughly. I'm not familiar with the GNOME shell JavaScript API, so I don't know what might have had breaking changes in that regard.

## Checklist

- [x] Your code builds clean without any errors or warnings.
- [x] You are using approved terminology.