### PR TITLE
Fix network Unit of measure selection with bps

### DIFF
--- a/Resource_Monitor@Ory0n/extension.js
+++ b/Resource_Monitor@Ory0n/extension.js
@@ -2174,8 +2174,10 @@ const ResourceMonitor = GObject.registerClass(
 
       let exponent = 0;
 
-      if (unitMeasure && unitSuffixes.includes(unitMeasure.toUpperCase())) {
-        exponent = unitSuffixes.indexOf(unitMeasure.toUpperCase());
+      const normalizedUnit = isBits ? unitMeasure : unitMeasure?.toUpperCase();
+
+      if (unitMeasure && unitSuffixes.includes(normalizedUnit)) {
+        exponent = unitSuffixes.indexOf(normalizedUnit);
       } else {
         while (values.some(v => v >= factor ** (exponent + 1)) && exponent < 4) {
           exponent++;


### PR DESCRIPTION
The code was not working properly when `isBits=true`.

Resolves #115 

## Checklist

- [x] Your code builds clean without any errors or warnings.
- [x] You are using approved terminology.