### PR TITLE
Fix indicator button click on Gnome 50

### DIFF
--- a/Resource_Monitor@Ory0n/extension.js
+++ b/Resource_Monitor@Ory0n/extension.js
@@ -366,6 +366,7 @@ const ResourceMonitor = GObject.registerClass(
 
       this._connectSettingsSignals();
 
+      this.clear_actions();
       this.connect("button-press-event", this._clickManager.bind(this));
       this.connect("key-press-event", this._onKeyPressEvent.bind(this));
 


### PR DESCRIPTION
## Summary

Very simple fix to address broken app indicator mouse click on Gnome 50.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation only
- [ ] Translation update

## Validation

- [x] `make validate` passes locally.
- [x] I tested this change in GNOME Shell.
- [x] Tested on GNOME Shell version(s): 50

From what I've read this change should be safe all the way back to Gnome 45, but I haven't tested it myself.

## Documentation and i18n

N/A

## GNOME Consistency Checklist

N/A

## Linked Issues

Fixes #126 #127

## Target Branch

`master`, because `develop` is behind.
