### PR TITLE
fix(panel): hide empty monitor groups

### DIFF
--- a/Resource_Monitor@Ory0n/extension.js
+++ b/Resource_Monitor@Ory0n/extension.js
@@ -53,6 +53,7 @@ import {
   applySecondarySeparatorStyle,
   buildMainGui,
   createMainGui,
+  syncMainGuiVisibility,
 } from "./panel/mainGui.js";
 import {
   detectCapabilities,
@@ -1679,6 +1680,10 @@ const ResourceMonitor = GObject.registerClass(
       syncThermalCpuVisibility(this);
     }
 
+    _syncMainGuiVisibility() {
+      syncMainGuiVisibility(this);
+    }
+
     _refreshHandler(forceGpu = false) {
       return refreshHandler(this, forceGpu);
     }
@@ -1839,6 +1844,8 @@ const ResourceMonitor = GObject.registerClass(
           element.hide();
         });
       }
+
+      this._syncMainGuiVisibility();
     }
 
     _basicItemWidth(width, element) {

--- a/Resource_Monitor@Ory0n/panel/mainGui.js
+++ b/Resource_Monitor@Ory0n/panel/mainGui.js
@@ -3,6 +3,7 @@ import Gio from "gi://Gio";
 import St from "gi://St";
 
 import { DiskContainerSpace, DiskContainerStats, GpuContainer } from "./containers.js";
+import { getPanelGroupVisibility } from "../services/visibility.js";
 
 function _addStyleClasses(actor, classes) {
   classes.forEach((cssClass) => actor.add_style_class_name(cssClass));
@@ -325,8 +326,35 @@ export function buildMainGui(indicator) {
   });
 
   applySecondarySeparatorStyle(indicator);
+  syncMainGuiVisibility(indicator);
 
   if (indicator._box.get_parent() !== indicator) {
     indicator.add_child(indicator._box);
   }
+}
+
+export function syncMainGuiVisibility(indicator) {
+  const visibility = getPanelGroupVisibility(indicator);
+  const groupsByItem = {
+    cpu: indicator._cpuGroup,
+    ram: indicator._ramGroup,
+    swap: indicator._swapGroup,
+    stats: indicator._diskStatsGroup,
+    space: indicator._diskSpaceGroup,
+    eth: indicator._ethGroup,
+    wlan: indicator._wlanGroup,
+    gpu: indicator._gpuGroup,
+  };
+
+  Object.entries(groupsByItem).forEach(([item, group]) => {
+    if (!group) {
+      return;
+    }
+
+    if (visibility[item]) {
+      group.show();
+    } else {
+      group.hide();
+    }
+  });
 }

--- a/Resource_Monitor@Ory0n/services/visibility.js
+++ b/Resource_Monitor@Ory0n/services/visibility.js
@@ -36,6 +36,27 @@ export function hasVisibleGpu(indicator) {
   );
 }
 
+export function getPanelGroupVisibility(indicator) {
+  return {
+    cpu:
+      indicator._cpuStatus ||
+      hasVisibleCpuFrequency(indicator) ||
+      indicator._cpuLoadAverageStatus ||
+      hasVisibleThermalCpuTemperature(indicator),
+    ram: indicator._ramStatus,
+    swap: indicator._swapStatus,
+    stats: indicator._diskStatsStatus,
+    space: indicator._diskSpaceStatus,
+    eth:
+      indicator._netEthStatus &&
+      (indicator._nmEthStatus || !indicator._netAutoHideStatus),
+    wlan:
+      indicator._netWlanStatus &&
+      (indicator._nmWlanStatus || !indicator._netAutoHideStatus),
+    gpu: hasVisibleGpu(indicator),
+  };
+}
+
 export function syncCpuFrequencyVisibility(indicator) {
   indicator._basicItemStatus(
     hasVisibleCpuFrequency(indicator),

--- a/tests/runtime-smoke.js
+++ b/tests/runtime-smoke.js
@@ -16,6 +16,7 @@ import {
   parseLoadAverage,
 } from "../Resource_Monitor@Ory0n/runtime/metrics.js";
 import { buildNetworkSample } from "../Resource_Monitor@Ory0n/runtime/network.js";
+import { getPanelGroupVisibility } from "../Resource_Monitor@Ory0n/services/visibility.js";
 
 function assert(condition, message) {
   if (!condition) {
@@ -40,6 +41,43 @@ function assertThrows(callback, message) {
   if (!didThrow) {
     throw new Error(message);
   }
+}
+
+function createVisibilityIndicator(overrides = {}) {
+  const defaults = {
+    _capabilities: {
+      cpuFrequency: false,
+      gpu: false,
+      thermalHwmon: false,
+    },
+    _cpuStatus: false,
+    _cpuFrequencyStatus: false,
+    _cpuLoadAverageStatus: false,
+    _thermalCpuTemperatureStatus: false,
+    _thermalCpuTemperatureDevices: [],
+    _ramStatus: false,
+    _swapStatus: false,
+    _diskStatsStatus: false,
+    _diskSpaceStatus: false,
+    _netEthStatus: false,
+    _netWlanStatus: false,
+    _netAutoHideStatus: false,
+    _nmEthStatus: false,
+    _nmWlanStatus: false,
+    _gpuStatus: false,
+    _thermalGpuTemperatureStatus: false,
+    _gpuDevices: [],
+    _thermalGpuTemperatureDevices: [],
+  };
+
+  return {
+    ...defaults,
+    ...overrides,
+    _capabilities: {
+      ...defaults._capabilities,
+      ...(overrides._capabilities ?? {}),
+    },
+  };
 }
 
 function testDiskSerializationRoundtrip() {
@@ -340,6 +378,68 @@ function testLoadAverageInvalidInputFallback() {
   );
 }
 
+function testPanelGroupVisibilityRamOnly() {
+  const visibility = getPanelGroupVisibility(
+    createVisibilityIndicator({
+      _ramStatus: true,
+    })
+  );
+
+  assert(visibility.ram === true, "RAM group should be visible");
+  assert(visibility.cpu === false, "CPU group should be hidden");
+  assert(visibility.swap === false, "Swap group should be hidden");
+  assert(visibility.stats === false, "Disk stats group should be hidden");
+  assert(visibility.space === false, "Disk space group should be hidden");
+  assert(visibility.eth === false, "Ethernet group should be hidden");
+  assert(visibility.wlan === false, "Wi-Fi group should be hidden");
+  assert(visibility.gpu === false, "GPU group should be hidden");
+}
+
+function testPanelGroupVisibilityCpuSecondaryMetric() {
+  const visibility = getPanelGroupVisibility(
+    createVisibilityIndicator({
+      _capabilities: {
+        cpuFrequency: true,
+      },
+      _cpuFrequencyStatus: true,
+    })
+  );
+
+  assert(
+    visibility.cpu === true,
+    "CPU group should be visible for CPU frequency without CPU usage"
+  );
+  assert(visibility.ram === false, "RAM group should be hidden");
+}
+
+function testPanelGroupVisibilityNetworkAutoHide() {
+  const disconnected = getPanelGroupVisibility(
+    createVisibilityIndicator({
+      _netAutoHideStatus: true,
+      _netEthStatus: true,
+      _nmEthStatus: false,
+    })
+  );
+
+  assert(
+    disconnected.eth === false,
+    "Ethernet group should be hidden when auto-hide is enabled and disconnected"
+  );
+
+  const connected = getPanelGroupVisibility(
+    createVisibilityIndicator({
+      _netAutoHideStatus: true,
+      _netEthStatus: true,
+      _nmEthStatus: true,
+    })
+  );
+
+  assert(
+    connected.eth === true,
+    "Ethernet group should be visible when auto-hide is enabled and connected"
+  );
+}
+
 testDiskSerializationRoundtrip();
 testLegacySettingsEntriesAreRejected();
 testGpuSerializationRoundtrip();
@@ -352,5 +452,8 @@ testDiskStatsSectorConversion();
 testNetworkCounterReset();
 testNetworkParsingWithoutTrailingNewline();
 testLoadAverageInvalidInputFallback();
+testPanelGroupVisibilityRamOnly();
+testPanelGroupVisibilityCpuSecondaryMetric();
+testPanelGroupVisibilityNetworkAutoHide();
 
 console.log("Runtime smoke tests passed.");


### PR DESCRIPTION
## Summary

Fixes a panel spacing regression introduced in version 27 where disabled resource groups still reserved horizontal space in the GNOME top bar.

When only one item is visible, for example RAM usage, the indicator could still include spacing for hidden groups like CPU, swap, disk, network, and GPU. This made the panel item much wider than its visible content.

This change keeps the existing item order behavior, but hides whole panel groups when none of their metrics are visible.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation only
- [ ] Translation update

## Validation

- [x] `make validate` passes locally.
- [x] I tested this change in GNOME Shell.
- [x] Tested on GNOME Shell version(s): 46
- [x] Tested on Ubuntu 24.04.4 LTS, Wayland.
- [x] Verified the RAM-only indicator no longer reserves empty space after disabled groups.

## Documentation and i18n

- [x] No documentation changes needed.
- [x] No translatable strings changed.

## GNOME consistency checklist

- [x] UI behavior remains coherent with GNOME conventions.
- [x] Preferences follow existing GTK4/Libadwaita patterns.
- [x] Schema/settings changes are backward compatible.

## Linked issues

Fixes #129

## Target branch

`develop`
