### PR TITLE
fix(panel): avoid iconless layout spacing

### DIFF
--- a/Resource_Monitor@Ory0n/extension.js
+++ b/Resource_Monitor@Ory0n/extension.js
@@ -53,6 +53,7 @@ import {
   applySecondarySeparatorStyle,
   buildMainGui,
   createMainGui,
+  syncMainGuiVisibility,
 } from "./panel/mainGui.js";
 import {
   detectCapabilities,
@@ -1679,6 +1680,10 @@ const ResourceMonitor = GObject.registerClass(
       syncThermalCpuVisibility(this);
     }
 
+    _syncMainGuiVisibility() {
+      syncMainGuiVisibility(this);
+    }
+
     _refreshHandler(forceGpu = false) {
       return refreshHandler(this, forceGpu);
     }
@@ -1839,6 +1844,8 @@ const ResourceMonitor = GObject.registerClass(
           element.hide();
         });
       }
+
+      this._syncMainGuiVisibility();
     }
 
     _basicItemWidth(width, element) {

--- a/Resource_Monitor@Ory0n/extension.js
+++ b/Resource_Monitor@Ory0n/extension.js
@@ -633,8 +633,8 @@ const ResourceMonitor = GObject.registerClass(
       createMainGui(this);
     }
 
-    _buildMainGui() {
-      buildMainGui(this);
+    _buildMainGui(options = {}) {
+      buildMainGui(this, options);
     }
 
     // SETTINGS
@@ -855,7 +855,13 @@ const ResourceMonitor = GObject.registerClass(
     }
 
     _iconsStatusChanged() {
+      const previousIconsStatus = this._iconsStatus;
       this._iconsStatus = this._settings.get_boolean(ICONS_STATUS);
+
+      if (previousIconsStatus !== this._iconsStatus && this._box?.get_parent()) {
+        this._box.remove_all_children();
+        this._buildMainGui({ refresh: false });
+      }
 
       if (this._iconsStatus) {
         if (

--- a/Resource_Monitor@Ory0n/panel/mainGui.js
+++ b/Resource_Monitor@Ory0n/panel/mainGui.js
@@ -11,6 +11,7 @@ function _addStyleClasses(actor, classes) {
 
 function _createGroupBox(name) {
   const box = new St.BoxLayout({
+    x_align: Clutter.ActorAlign.CENTER,
     style_class: "resource-monitor-group",
   });
   box.add_style_class_name(`resource-monitor-group-${name}`);
@@ -98,8 +99,8 @@ export function applySecondarySeparatorStyle(indicator) {
   }
 }
 
-function _appendCpuChildren(indicator, addChild, iconsPosition) {
-  if (iconsPosition === "left") {
+function _appendCpuChildren(indicator, addChild, iconsPosition, iconsStatus) {
+  if (iconsStatus && iconsPosition === "left") {
     addChild(indicator._cpuIcon);
   }
 
@@ -117,38 +118,46 @@ function _appendCpuChildren(indicator, addChild, iconsPosition) {
   addChild(indicator._cpuLoadAverageValue);
   addChild(indicator._cpuLoadAverageBracketEnd);
 
-  if (iconsPosition !== "left") {
+  if (iconsStatus && iconsPosition !== "left") {
     addChild(indicator._cpuIcon);
   }
 }
 
-function _appendSimpleChildren(icon, value, unit, addChild, iconsPosition) {
-  if (iconsPosition === "left") {
+function _appendSimpleChildren(
+  icon,
+  value,
+  unit,
+  addChild,
+  iconsPosition,
+  iconsStatus
+) {
+  if (iconsStatus && iconsPosition === "left") {
     addChild(icon);
   }
 
   addChild(value);
   addChild(unit);
 
-  if (iconsPosition !== "left") {
+  if (iconsStatus && iconsPosition !== "left") {
     addChild(icon);
   }
 }
 
-function _appendSingleBoxChildren(icon, box, addChild, iconsPosition) {
-  if (iconsPosition === "left") {
+function _appendSingleBoxChildren(icon, box, addChild, iconsPosition, iconsStatus) {
+  if (iconsStatus && iconsPosition === "left") {
     addChild(icon);
   }
 
   addChild(box);
 
-  if (iconsPosition !== "left") {
+  if (iconsStatus && iconsPosition !== "left") {
     addChild(icon);
   }
 }
 
 export function createMainGui(indicator) {
   indicator._box = new St.BoxLayout({
+    x_align: Clutter.ActorAlign.CENTER,
     style_class: "resource-monitor-box",
   });
   indicator._cpuGroup = _createGroupBox("cpu");
@@ -231,17 +240,26 @@ export function createMainGui(indicator) {
   indicator._gpuBox = new GpuContainer();
 }
 
-export function buildMainGui(indicator) {
-  indicator._refreshGui();
+export function buildMainGui(indicator, options = {}) {
+  const { refresh = true } = options;
+
+  if (refresh) {
+    indicator._refreshGui();
+  }
 
   const iconsPosition = indicator._iconsPosition;
+  const iconsStatus = indicator._iconsStatus;
   indicator._box.remove_style_class_name("resource-monitor-icons-left");
   indicator._box.remove_style_class_name("resource-monitor-icons-right");
+  indicator._box.remove_style_class_name("resource-monitor-icons-hidden");
   indicator._box.add_style_class_name(
     iconsPosition === "left"
       ? "resource-monitor-icons-left"
       : "resource-monitor-icons-right"
   );
+  if (!iconsStatus) {
+    indicator._box.add_style_class_name("resource-monitor-icons-hidden");
+  }
 
   const groupsByItem = {
     cpu: indicator._cpuGroup,
@@ -255,7 +273,7 @@ export function buildMainGui(indicator) {
   };
 
   _replaceGroupChildren(indicator._cpuGroup, (addChild) =>
-    _appendCpuChildren(indicator, addChild, iconsPosition)
+    _appendCpuChildren(indicator, addChild, iconsPosition, iconsStatus)
   );
   _replaceGroupChildren(indicator._ramGroup, (addChild) =>
     _appendSimpleChildren(
@@ -263,7 +281,8 @@ export function buildMainGui(indicator) {
       indicator._ramValue,
       indicator._ramUnit,
       addChild,
-      iconsPosition
+      iconsPosition,
+      iconsStatus
     )
   );
   _replaceGroupChildren(indicator._swapGroup, (addChild) =>
@@ -272,7 +291,8 @@ export function buildMainGui(indicator) {
       indicator._swapValue,
       indicator._swapUnit,
       addChild,
-      iconsPosition
+      iconsPosition,
+      iconsStatus
     )
   );
   _replaceGroupChildren(indicator._diskStatsGroup, (addChild) =>
@@ -280,7 +300,8 @@ export function buildMainGui(indicator) {
       indicator._diskStatsIcon,
       indicator._diskStatsBox,
       addChild,
-      iconsPosition
+      iconsPosition,
+      iconsStatus
     )
   );
   _replaceGroupChildren(indicator._diskSpaceGroup, (addChild) =>
@@ -288,7 +309,8 @@ export function buildMainGui(indicator) {
       indicator._diskSpaceIcon,
       indicator._diskSpaceBox,
       addChild,
-      iconsPosition
+      iconsPosition,
+      iconsStatus
     )
   );
   _replaceGroupChildren(indicator._ethGroup, (addChild) =>
@@ -297,7 +319,8 @@ export function buildMainGui(indicator) {
       indicator._ethValue,
       indicator._ethUnit,
       addChild,
-      iconsPosition
+      iconsPosition,
+      iconsStatus
     )
   );
   _replaceGroupChildren(indicator._wlanGroup, (addChild) =>
@@ -306,7 +329,8 @@ export function buildMainGui(indicator) {
       indicator._wlanValue,
       indicator._wlanUnit,
       addChild,
-      iconsPosition
+      iconsPosition,
+      iconsStatus
     )
   );
   _replaceGroupChildren(indicator._gpuGroup, (addChild) =>
@@ -314,7 +338,8 @@ export function buildMainGui(indicator) {
       indicator._gpuIcon,
       indicator._gpuBox,
       addChild,
-      iconsPosition
+      iconsPosition,
+      iconsStatus
     )
   );
 

--- a/Resource_Monitor@Ory0n/panel/mainGui.js
+++ b/Resource_Monitor@Ory0n/panel/mainGui.js
@@ -3,6 +3,7 @@ import Gio from "gi://Gio";
 import St from "gi://St";
 
 import { DiskContainerSpace, DiskContainerStats, GpuContainer } from "./containers.js";
+import { getPanelGroupVisibility } from "../services/visibility.js";
 
 function _addStyleClasses(actor, classes) {
   classes.forEach((cssClass) => actor.add_style_class_name(cssClass));
@@ -325,8 +326,35 @@ export function buildMainGui(indicator) {
   });
 
   applySecondarySeparatorStyle(indicator);
+  syncMainGuiVisibility(indicator);
 
   if (indicator._box.get_parent() !== indicator) {
     indicator.add_child(indicator._box);
   }
+}
+
+export function syncMainGuiVisibility(indicator) {
+  const visibility = getPanelGroupVisibility(indicator);
+  const groupsByItem = {
+    cpu: indicator._cpuGroup,
+    ram: indicator._ramGroup,
+    swap: indicator._swapGroup,
+    stats: indicator._diskStatsGroup,
+    space: indicator._diskSpaceGroup,
+    eth: indicator._ethGroup,
+    wlan: indicator._wlanGroup,
+    gpu: indicator._gpuGroup,
+  };
+
+  Object.entries(groupsByItem).forEach(([item, group]) => {
+    if (!group) {
+      return;
+    }
+
+    if (visibility[item]) {
+      group.show();
+    } else {
+      group.hide();
+    }
+  });
 }

--- a/Resource_Monitor@Ory0n/services/visibility.js
+++ b/Resource_Monitor@Ory0n/services/visibility.js
@@ -36,6 +36,27 @@ export function hasVisibleGpu(indicator) {
   );
 }
 
+export function getPanelGroupVisibility(indicator) {
+  return {
+    cpu:
+      indicator._cpuStatus ||
+      hasVisibleCpuFrequency(indicator) ||
+      indicator._cpuLoadAverageStatus ||
+      hasVisibleThermalCpuTemperature(indicator),
+    ram: indicator._ramStatus,
+    swap: indicator._swapStatus,
+    stats: indicator._diskStatsStatus,
+    space: indicator._diskSpaceStatus,
+    eth:
+      indicator._netEthStatus &&
+      (indicator._nmEthStatus || !indicator._netAutoHideStatus),
+    wlan:
+      indicator._netWlanStatus &&
+      (indicator._nmWlanStatus || !indicator._netAutoHideStatus),
+    gpu: hasVisibleGpu(indicator),
+  };
+}
+
 export function syncCpuFrequencyVisibility(indicator) {
   indicator._basicItemStatus(
     hasVisibleCpuFrequency(indicator),

--- a/Resource_Monitor@Ory0n/stylesheet.css
+++ b/Resource_Monitor@Ory0n/stylesheet.css
@@ -2,6 +2,10 @@
   spacing: 0.35em;
 }
 
+.resource-monitor-box.resource-monitor-icons-hidden {
+  spacing: 0.65em;
+}
+
 .resource-monitor-group {
   spacing: 0.05em;
 }
@@ -14,6 +18,10 @@
 .resource-monitor-unit {
   padding-left: 0.125em;
   padding-right: 0.3em;
+}
+
+.resource-monitor-box.resource-monitor-icons-hidden .resource-monitor-unit {
+  padding-right: 0;
 }
 
 .resource-monitor-bracket {

--- a/tests/runtime-smoke.js
+++ b/tests/runtime-smoke.js
@@ -16,6 +16,7 @@ import {
   parseLoadAverage,
 } from "../Resource_Monitor@Ory0n/runtime/metrics.js";
 import { buildNetworkSample } from "../Resource_Monitor@Ory0n/runtime/network.js";
+import { getPanelGroupVisibility } from "../Resource_Monitor@Ory0n/services/visibility.js";
 
 function assert(condition, message) {
   if (!condition) {
@@ -40,6 +41,43 @@ function assertThrows(callback, message) {
   if (!didThrow) {
     throw new Error(message);
   }
+}
+
+function createVisibilityIndicator(overrides = {}) {
+  const defaults = {
+    _capabilities: {
+      cpuFrequency: false,
+      gpu: false,
+      thermalHwmon: false,
+    },
+    _cpuStatus: false,
+    _cpuFrequencyStatus: false,
+    _cpuLoadAverageStatus: false,
+    _thermalCpuTemperatureStatus: false,
+    _thermalCpuTemperatureDevices: [],
+    _ramStatus: false,
+    _swapStatus: false,
+    _diskStatsStatus: false,
+    _diskSpaceStatus: false,
+    _netEthStatus: false,
+    _netWlanStatus: false,
+    _netAutoHideStatus: false,
+    _nmEthStatus: false,
+    _nmWlanStatus: false,
+    _gpuStatus: false,
+    _thermalGpuTemperatureStatus: false,
+    _gpuDevices: [],
+    _thermalGpuTemperatureDevices: [],
+  };
+
+  return {
+    ...defaults,
+    ...overrides,
+    _capabilities: {
+      ...defaults._capabilities,
+      ...(overrides._capabilities ?? {}),
+    },
+  };
 }
 
 function testDiskSerializationRoundtrip() {
@@ -340,6 +378,68 @@ function testLoadAverageInvalidInputFallback() {
   );
 }
 
+function testPanelGroupVisibilityRamOnly() {
+  const visibility = getPanelGroupVisibility(
+    createVisibilityIndicator({
+      _ramStatus: true,
+    })
+  );
+
+  assert(visibility.ram === true, "RAM group should be visible");
+  assert(visibility.cpu === false, "CPU group should be hidden");
+  assert(visibility.swap === false, "Swap group should be hidden");
+  assert(visibility.stats === false, "Disk stats group should be hidden");
+  assert(visibility.space === false, "Disk space group should be hidden");
+  assert(visibility.eth === false, "Ethernet group should be hidden");
+  assert(visibility.wlan === false, "Wi-Fi group should be hidden");
+  assert(visibility.gpu === false, "GPU group should be hidden");
+}
+
+function testPanelGroupVisibilityCpuSecondaryMetric() {
+  const visibility = getPanelGroupVisibility(
+    createVisibilityIndicator({
+      _capabilities: {
+        cpuFrequency: true,
+      },
+      _cpuFrequencyStatus: true,
+    })
+  );
+
+  assert(
+    visibility.cpu === true,
+    "CPU group should be visible for CPU frequency without CPU usage"
+  );
+  assert(visibility.ram === false, "RAM group should be hidden");
+}
+
+function testPanelGroupVisibilityNetworkAutoHide() {
+  const disconnected = getPanelGroupVisibility(
+    createVisibilityIndicator({
+      _netAutoHideStatus: true,
+      _netEthStatus: true,
+      _nmEthStatus: false,
+    })
+  );
+
+  assert(
+    disconnected.eth === false,
+    "Ethernet group should be hidden when auto-hide is enabled and disconnected"
+  );
+
+  const connected = getPanelGroupVisibility(
+    createVisibilityIndicator({
+      _netAutoHideStatus: true,
+      _netEthStatus: true,
+      _nmEthStatus: true,
+    })
+  );
+
+  assert(
+    connected.eth === true,
+    "Ethernet group should be visible when auto-hide is enabled and connected"
+  );
+}
+
 testDiskSerializationRoundtrip();
 testLegacySettingsEntriesAreRejected();
 testGpuSerializationRoundtrip();
@@ -352,5 +452,8 @@ testDiskStatsSectorConversion();
 testNetworkCounterReset();
 testNetworkParsingWithoutTrailingNewline();
 testLoadAverageInvalidInputFallback();
+testPanelGroupVisibilityRamOnly();
+testPanelGroupVisibilityCpuSecondaryMetric();
+testPanelGroupVisibilityNetworkAutoHide();
 
 console.log("Runtime smoke tests passed.");


### PR DESCRIPTION
## Summary

Fixes iconless panel alignment so single-item displays stay visually centered.

When monitor icons were disabled, a simple display such as RAM percentage only could appear shifted to the left inside the GNOME top bar pill, leaving a small but noticeable extra space on the right.

This change keeps icons working normally when enabled, but removes icon actors from the panel layout when icons are disabled so they no longer affect alignment. It also keeps the spacing between multiple iconless monitor sections consistent with the previous visual spacing.

Note: this PR is stacked on top of #130 because it adjusts the panel group layout introduced there. It should be reviewed after #130.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation only
- [ ] Translation update

## Validation

- [x] `make validate` passes locally.
- [x] I tested this change in GNOME Shell.
- [x] Tested on GNOME Shell version(s): 46
- [x] Tested on Ubuntu 24.04.4 LTS, Wayland.
- [x] Tested icons disabled with RAM-only panel display.
- [x] Tested toggling icons on and off keeps icons working when enabled.

## Documentation and i18n

- [x] No documentation changes needed.
- [x] No translatable strings changed.

## GNOME Consistency Checklist

- [x] UI behavior remains coherent with GNOME conventions.
- [x] Preferences follow existing GTK4/Libadwaita patterns.
- [x] Schema/settings changes are backward compatible.

## Linked Issues

Related to #129

Stacked on #130

## Target Branch

`develop`
